### PR TITLE
Changed .replaceAll to .replace

### DIFF
--- a/lib/articles.js
+++ b/lib/articles.js
@@ -1,4 +1,4 @@
-const fs = require('fs');
+const fs = require("fs");
 
 const RSS_TO_JSON = `https://api.rss2json.com/v1/api.json?api_key=${process.env.RSS_2_JSON_API_KEY}&rss_url=`;
 
@@ -9,17 +9,17 @@ const fetchFeedByUrl = async (url) => {
 export const getAllArticles = async () => {
   const articles = [];
 
-  const feedUrls = fs.readFileSync('feed.txt', 'utf8').split('\n');
+  const feedUrls = fs.readFileSync("feed.txt", "utf8").split("\n");
   for (let feedUrl of feedUrls) {
     const feed = await fetchFeedByUrl(feedUrl);
-    if (!feed.items || feed.status !== 'ok') {
+    if (!feed.items || feed.status !== "ok") {
       return;
     }
 
     feed.items.forEach((item) => {
       const url = new URL(item.link || item.guid);
-      const hostAndPathname = url.host + url.pathname.replace(/\/$/, '');
-      const slug = hostAndPathname.replaceAll(/(\.|\/)/g, '-');
+      const hostAndPathname = url.host + url.pathname.replace(/\/$/, "");
+      const slug = hostAndPathname.replace(/(\.|\/)/g, "-");
 
       articles.push({ ...item, slug, feedTitle: feed.feed.title });
     });


### PR DESCRIPTION
After cloning, the site wouldn't render because of a type error with the .replaceAll() function in lib/articles.js. I changed it to the .replace() function and everything worked as shown in https://ashleemboyer.com/create-your-own-nextjs-rss-reader-app